### PR TITLE
Fix the case of using a quote inside a homepage article title

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -19,7 +19,7 @@ var $sitehead = $('#site-head');
 		}, 1000);
 	}
 	function srcToAnchorWithTitle (str) {
-		var $el = $('#' + str);
+		var $el = $('#' + str.replace("'","\\\'"));
 		if ($el.length) {
 			srcTo($el);
 		}


### PR DESCRIPTION
This fix is only for the weird case that if you use a quote in the title like so 
```md
---
title: "You're the best"
weight: 30
header_menu: true
---
```
This in terms transform it to You\'re the best as a string which once evaluated by jquery gives the correct ID, thus the double escape