### PR TITLE
Activate last section heading when approaching footer

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -81,24 +81,30 @@ var $sitehead = $("#site-head");
         }
 
         $post.each(function () {
-          var f = $(this).offset().top;
-          var b = $(this).offset().top + $(this).height();
-          var t = $(this).parent(".post-holder").index();
-          var i = $(".fn-item[item_index='" + t + "']");
-          var a = $(this)
-            .parent(".post-holder")
-            .prev(".post-holder")
-            .find(".post-after");
-
-          $(this).attr("item_index", t);
-
-          if (w >= f && w <= b) {
-            i.addClass("active");
-            a.fadeOut("slow");
+          if (($(window).height() + w) > ($(document).height() - $(".site-footer").height())) {
+            var l = $postholder.length;
+            $(".fn-item[item_index='" + (l - 1) + "']").removeClass("active")
+            $(".fn-item[item_index='" + (l) + "']").addClass("active")
           } else {
-            i.removeClass("active");
-            a.fadeIn("slow");
-          }
+            var f = $(this).offset().top;
+            var b = $(this).offset().top + $(this).height();
+            var t = $(this).parent(".post-holder").index();
+            var i = $(".fn-item[item_index='" + t + "']");
+            var a = $(this)
+              .parent(".post-holder")
+              .prev(".post-holder")
+              .find(".post-after");
+
+            $(this).attr("item_index", t);
+
+            if (w >= f && w <= b) {
+              i.addClass("active");
+              a.fadeOut("slow");
+            } else {
+              i.removeClass("active");
+              a.fadeIn("slow");
+            }
+        }
         });
       });
     }


### PR DESCRIPTION
Hi everyone,

i want to propose a solution for #20 . 

Currently, the activation of section headers is triggered when the container holding a section, i.e., page, crosses the upper window border. If the last section is small, like in the example site, the container never crosses the upper window border and thus the section header is not activated.

I would suggest to first check whether the footer is visible and if so, activate the last section heading.