### PR TITLE
Add safeHTML to blog-title

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
     <div class="vertical">
         <div id="site-head-content" class="inner">
 
-            {{ with .Params.header_headline }}<h1 class="blog-title">{{ . }}</h1>{{ end }}
+            {{ with .Params.header_headline }}<h1 class="blog-title">{{ . | safeHTML }}</h1>{{ end }}
             {{ with .Params.header_subheadline }}<h2 class="blog-description">{{ . }}</h2>{{ end }}
 
             {{ range where $sections ".Params.header_menu" "eq" true }}


### PR DESCRIPTION
SafeHTML signals to the go templating engine that the html in this string is considered safe and does not need to be escaped. This will allow me to add some additional markup to the title. In my case, I use an explicit <br/> tag to control the line break.