### PR TITLE
Add font-display: swap property to avoid invisible text

### DIFF
--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -20,6 +20,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-300.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-300.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -34,6 +35,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-regular.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -48,6 +50,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-600.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-600.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -62,6 +65,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-700.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -76,6 +80,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 800;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-800.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-800.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -90,6 +95,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 300;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-300italic.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-300italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -104,6 +110,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 400;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-italic.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -118,6 +125,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 600;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-600italic.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-600italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -132,6 +140,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 700;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-700italic.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-700italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -146,6 +155,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 800;
+  font-display: swap;
   src: url('../fonts/open-sans-v27-latin-800italic.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-v27-latin-800italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -164,6 +174,7 @@
   font-family: 'Open Sans Condensed';
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url('../fonts/open-sans-condensed-v21-latin-300.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-condensed-v21-latin-300.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -177,6 +188,7 @@
 @font-face {
   font-family: 'Open Sans Condensed';
   font-style: italic;
+  font-display: swap;
   font-weight: 300;
   src: url('../fonts/open-sans-condensed-v21-latin-300italic.eot'); /* IE9 Compat Modes */
   src: local(''),
@@ -192,6 +204,7 @@
   font-family: 'Open Sans Condensed';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: url('../fonts/open-sans-condensed-v21-latin-700.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/open-sans-condensed-v21-latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -210,6 +223,7 @@
   font-family: 'Oswald';
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url('../fonts/oswald-v40-latin-300.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/oswald-v40-latin-300.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -224,6 +238,7 @@
   font-family: 'Oswald';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url('../fonts/oswald-v40-latin-regular.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/oswald-v40-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -238,6 +253,7 @@
   font-family: 'Oswald';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: url('../fonts/oswald-v40-latin-700.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/oswald-v40-latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -256,6 +272,7 @@
   font-family: 'Roboto Slab';
   font-style: normal;
   font-weight: 100;
+  font-display: swap;
   src: url('../fonts/roboto-slab-v16-latin-100.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/roboto-slab-v16-latin-100.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -270,6 +287,7 @@
   font-family: 'Roboto Slab';
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url('../fonts/roboto-slab-v16-latin-300.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/roboto-slab-v16-latin-300.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -284,6 +302,7 @@
   font-family: 'Roboto Slab';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url('../fonts/roboto-slab-v16-latin-regular.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/roboto-slab-v16-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -298,6 +317,7 @@
   font-family: 'Roboto Slab';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: url('../fonts/roboto-slab-v16-latin-700.eot'); /* IE9 Compat Modes */
   src: local(''),
        url('../fonts/roboto-slab-v16-latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */


### PR DESCRIPTION
Hi!
When checking my website with Lighthouse, it gave me this:
>  Ensure text remains visible during webfont load 
> > Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading.

So i added this to all `@font-face`s <3

Didn't know what to do about forkawesome, because those are icons and you don't have a system fallback for those - so i left this