### PR TITLE
external links - external links in main menu

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,6 +2,8 @@
 {{ $headless := .Site.GetPage "/homepage" }}
 {{ $sections := $headless.Resources.ByType "page" }}
 {{ $sections := cond .Site.BuildDrafts $sections (where $sections "Draft" "==" false) }}
+{{ $filtered := where $sections "Params.external" "==" nil }}
+
 <header id="site-head" {{ with .Params.header_image }}style="background-image: url({{ . }})"{{ end }}>
     <div class="vertical">
         <div id="site-head-content" class="inner">
@@ -10,7 +12,11 @@
             {{ with .Params.header_subheadline }}<h2 class="blog-description">{{ . }}</h2>{{ end }}
 
             {{ range where $sections ".Params.header_menu" "eq" true }}
+	      {{ if isset .Params "external" }}
+	         <a class='btn site-menu' href='{{ .Params.external  }}'>{{ .Title }}</a>
+	      {{ else }}
                  <a class='btn site-menu' data-title-anchor='{{ anchorize .Title }}'>{{ .Title }}</a>
+              {{ end }}
             {{ end }}
             <i id='header-arrow' class="fa fa-angle-down"></i>
         </div>
@@ -20,7 +26,7 @@
 
     <div class='fixed-nav'>
     </div>
-    {{ range $index_val, $elem_val := $sections }}
+    {{ range $index_val, $elem_val := $filtered }}
         <div class='post-holder'>
             <article id='{{ anchorize .Title }}' class='post {{ if eq $index_val 0 }}first{{ end }} {{ if eq (add $index_val 1) (len $sections) }}last{{ end }}'>
                 <header class="post-header">


### PR DESCRIPTION
This change adds support for an "external" link in the main menu on the title page.
An external link can be added the keyword "external" to the front matter of a page, the value of the "external" key should be the external URL. 
An example page is here: https://evilrobots.ai/  